### PR TITLE
Fix Github rendering * as italics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4521,7 +4521,9 @@ Problem 182
    An issue when choosing e is that there should not be too many unconcealed
    messages.
    For instance, let p=19 and q=37.
-   Then n=19*37=703 and φ=18*36=648.
+
+   Then $n = 19 \ast 37 = 703$ and $\phi = 18 \ast 36 = 648$.
+
    If we choose e=181, then, although gcd(181,648)=1 it turns out that all
    possible messages
    m (0≤m≤n-1) are unconcealed when calculating m^e mod n.
@@ -5343,8 +5345,11 @@ Problem 216
 
 
    Consider numbers t(n) of the form t(n) = 2n^2-1 with n > 1.
+
    The first such numbers are 7, 17, 31, 49, 71, 97, 127 and 161.
-   It turns out that only 49 = 7*7 and 161 = 7*23 are not prime.
+
+It turns out that only $49 = 7 \ast 7$ and $161 = 7 \ast 23$ are not prime.
+
    For n ≤ 10000 there are 2202 numbers t(n) that are prime.
 
    How many numbers t(n) are prime for n ≤ 50,000,000 ?
@@ -6490,8 +6495,10 @@ Give that length as your answer, rounded to three decimal places.
 
 Note: For convenience, the elevation function shown above is repeated
 below, in a form suitable for most programming languages:
-h=( 5000-0.005*(x*x+y*y+x*y)+12.5*(x+y) ) * exp(
--abs(0.000001*(x*x+y*y)-0.0015*(x+y)+0.7) )
+
+```php
+h=( 5000-0.005*(x*x+y*y+x*y)+12.5*(x+y) ) * exp( -abs(0.000001*(x*x+y*y)-0.0015*(x+y)+0.7) )
+```
 
 Answer: a5921e175a44d31e7f82f7f9a61a36af
 
@@ -6883,8 +6890,7 @@ Problem 278
    We therefore call f(5, 7) = 23.
    Similarly, it can be shown that f(6, 10, 15)=29 and f(14, 22, 77) = 195.
 
-   Find ∑ f(p*q,p*r,q*r), where p, q and r are prime numbers and p < q < r <
-   5000.
+Find $∑ f(p \ast q, p \ast r, q \ast r)$, where $p$, $q$ and $r$ are prime numbers and $p < q < r < 5000$.
 
    
    Answer: 7e680606b5e9890a19894dbdbbbd102a
@@ -7772,13 +7778,11 @@ entire 250 000 m^2 area. The [Duchy of Grand Fenwick](http://en.wikipedia.org/wi
 budget, and has asked you (their Royal Programmer) to compute what shape
 would get best maximum enclosed-area/wall-length ratio.
 
-You have done some preliminary calculations on a sheet of paper.For a 2000
-meter wall enclosing the 250 000 m^2 area theenclosed-area/wall-length
-ratio is 125.
-Although not allowed , but to get an idea if this is anything better: if
-you place a circle inside the square area touching the four sides the area
-will be equal to π*250^2 m^2 and the perimeter will be π*500 m, so the
-enclosed-area/wall-length ratio will also be 125.
+You have done some preliminary calculations on a sheet of paper.
+For a 2000 meter wall enclosing the 250 000 m² area the enclosed-area/wall-length ratio is 125.
+
+Although not allowed , but to get an idea if this is anything better:
+if you place a circle inside the square area touching the four sides the area will be equal to $\pi \ast 250^2 \text{ m}^2$ and the perimeter will be $\pi \ast 500 \text{ m}$, so the enclosed-area/wall-length ratio will also be 125.
 
 However, if you cut off from the square four triangles with sides 75 m, 75
 m and 75√2 m the total area becomes 238750 m^2 and the perimeter becomes
@@ -8744,10 +8748,9 @@ Problem 347
 ===========
 
 
-The largest integer ≤ 100 that is only divisible by both the primes 2 and
-3 is 96, as 96=32*3=2^5*3.For two distinct primes p and q let M(p,q,N) be
-the largest positive integer ≤N only divisibleby both p and q and
-M(p,q,N)=0 if such a positive integer does not exist.
+The largest integer ≤ 100 that is only divisible by both the primes 2 and 3 is 96, as $96 = 32 \ast 3 = 2^5 \ast 3$.
+
+For two _distinct_ primes p and q let M(p,q,N) be the largest positive integer ≤N only divisible by both p and q and M(p,q,N)=0 if such a positive integer does not exist.
 
 E.g. M(2,3,100)=96.
 M(3,5,100)=75 and not 90 because 90 is divisible by 2 ,3 and 5.
@@ -9257,7 +9260,7 @@ Problem 365
 
    Let M(n,k,m) denote the binomial coefficient C(n,k) modulo m.
 
-   Calculate ∑M(10^18,10^9,p*q*r) for 1000<p<q<r<5000 and p,q,r prime.
+Calculate $∑M(10^18, 10^9, p \ast q \ast r)$ for $1000 < p < q < r < 5000$ and p,q,r prime.
 
    
    Answer: 53addf69042b0cefbeb94f3bd3224918
@@ -11546,16 +11549,18 @@ Problem 451
    2, 4, 7, 8, 11, 13, 14.
    The modular inverses of these numbers modulo 15 are: 1, 8, 4, 13, 2, 11,
    7, 14
-   because
-   1*1 mod 15=1
-   2*8=16 mod 15=1
-   4*4=16 mod 15=1
-   7*13=91 mod 15=1
-   11*11=121 mod 15=1
-   14*14=196 mod 15=1
 
-   Let I(n) be the largest positive number m smaller than n-1 such that the
-   modular inverse of m modulo n equals m itself.
+because
+
+*   $1 * 1 \bmod 15 = 1$
+*   $2 * 8 = 16 \bmod 15 = 1$
+*   $4 * 4 = 16 \bmod 15 = 1$
+*   $7 * 13 = 91 \bmod 15 = 1$
+*   $11 * 11 = 121 \bmod 15 = 1$
+*   $14 * 14 = 196 \bmod 15 = 1$
+
+Let I(n) be the largest positive number m smaller than n-1 such that the modular inverse of m modulo n equals m itself.
+
    So I(15)=11.
    Also I(100)=51 and I(7)=1.
 


### PR DESCRIPTION
Escape * using LaTeX \ast where Github interprets them as italics.

For Problem 451, convert to a list to improve readability.

Fixes #42