### PR TITLE
Use nodejs 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 0.11
+node_js: 6
 install:
   - gem install mdl
   - npm install -g markdownlint-cli


### PR DESCRIPTION
The new version of remark fails on nodejs 0.11

c.f. https://travis-ci.org/jayvdb/PocketEuler/builds/244125395 for the error